### PR TITLE
feat(cli): Move build and deployment messages to correct place

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -2,16 +2,17 @@ package cmd
 
 import (
 	"fmt"
-	opConfig "github.com/onepanelio/cli/config"
-	"github.com/onepanelio/cli/files"
-	"github.com/onepanelio/cli/util"
-	"github.com/spf13/cobra"
 	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
 	"strings"
 	"time"
+
+	opConfig "github.com/onepanelio/cli/config"
+	"github.com/onepanelio/cli/files"
+	"github.com/onepanelio/cli/util"
+	"github.com/spf13/cobra"
 )
 
 // applyCmd represents the apply command
@@ -20,6 +21,8 @@ var applyCmd = &cobra.Command{
 	Short: "Applies application YAML to your Kubernetes cluster.",
 	Run: func(cmd *cobra.Command, args []string) {
 		configFilePath := "config.yaml"
+
+		log.Printf("Starting deployment...\n\n")
 
 		if len(args) > 1 {
 			configFilePath = args[0]
@@ -68,8 +71,6 @@ var applyCmd = &cobra.Command{
 			log.Printf("Error writing to temporary file: %v", err.Error())
 			return
 		}
-
-		fmt.Printf("Starting deployment...\n\n")
 
 		resApp := ""
 		errResApp := ""

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -6,12 +6,13 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
+
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/krusty"
 	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/types"
-	"strconv"
-	"strings"
 
 	opConfig "github.com/onepanelio/cli/config"
 	"github.com/onepanelio/cli/files"
@@ -42,6 +43,7 @@ var generateCmd = &cobra.Command{
 
 		kustomizeTemplate := TemplateFromSimpleOverlayedComponents(config.GetOverlayComponents(""))
 
+		log.Printf("Building...")
 		result, err := GenerateKustomizeResult(*config, kustomizeTemplate)
 		if err != nil {
 			log.Printf("Error generating result %v", err.Error())
@@ -63,7 +65,6 @@ func GenerateKustomizeResult(config opConfig.Config, kustomizeTemplate template.
 	manifestPath := config.Spec.ManifestsRepo
 	localManifestsCopyPath := ".manifests/cache"
 
-	log.Printf("Building...")
 	exists, err := files.Exists(localManifestsCopyPath)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
This fixes the issue with the "Building..." messages being repeated twice and moves the "Starting deployment..." message so it's displayed sooner.