### PR TITLE
feat: move generated files to .onepanel folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,7 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
-.manifest/
-.manifests/
+.onepanel/
 .idea
 config.yaml
 main

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -44,7 +44,7 @@ var applyCmd = &cobra.Command{
 			return
 		}
 
-		applicationKubernetesYamlFilePath := ".application.kubernetes.yaml"
+		applicationKubernetesYamlFilePath := ".onepanel/application.kubernetes.yaml"
 
 		existsApp, err := files.Exists(applicationKubernetesYamlFilePath)
 		if err != nil {
@@ -130,7 +130,7 @@ var applyCmd = &cobra.Command{
 			return
 		}
 
-		finalKubernetesYamlFilePath := ".kubernetes.yaml"
+		finalKubernetesYamlFilePath := ".onepanel/kubernetes.yaml"
 
 		exists, err := files.Exists(finalKubernetesYamlFilePath)
 		if err != nil {

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -64,7 +64,7 @@ func init() {
 // and running the kustomize command
 func GenerateKustomizeResult(config opConfig.Config, kustomizeTemplate template.Kustomize) (string, error) {
 	manifestPath := config.Spec.ManifestsRepo
-	localManifestsCopyPath := ".manifests/cache"
+	localManifestsCopyPath := ".onepanel/manifests/cache"
 
 	exists, err := files.Exists(localManifestsCopyPath)
 	if err != nil {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	manifestsFilePath = ".manifests"
+	manifestsFilePath = ".onepanel/manifests"
 )
 
 var (
@@ -92,7 +92,7 @@ var initCmd = &cobra.Command{
 		}
 
 		log.Printf("Initializing...")
-		configFile := ".cli_config.yaml"
+		configFile := ".onepanel/cli_config.yaml"
 		exists, err := files.Exists(configFile)
 		if err != nil {
 			log.Printf("[error] checking for config file %v", configFile)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,8 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
@@ -36,7 +37,7 @@ func Execute() {
 }
 
 func init() {
-	cobra.OnInitialize(initConfig)
+	cobra.OnInitialize(initConfig, createHiddenFolder)
 
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
@@ -69,4 +70,8 @@ func initConfig() {
 	if err := viper.ReadInConfig(); err == nil {
 		fmt.Println("Using config file:", viper.ConfigFileUsed())
 	}
+}
+
+func createHiddenFolder() {
+	os.MkdirAll(".onepanel", os.ModePerm)
 }

--- a/main.go
+++ b/main.go
@@ -15,7 +15,9 @@ limitations under the License.
 */
 package main
 
-import "github.com/onepanelio/cli/cmd"
+import (
+	"github.com/onepanelio/cli/cmd"
+)
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
This moves all generated files except for `params.yaml` and `config.yaml` to `.onepanel` folder.