### PR TITLE
Added code to generate applicationNodePoolOptions variable for the fl…

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -450,6 +450,8 @@ func generateApplicationNodePoolOptions(nodePoolData []*yaml2.Node) string {
 	applicationNodePoolOptions := []string{"|\n"}
 	var optionChunk []string
 	var prefix string
+	var optionChunkAppend string
+	addSingleQuotes := false
 	for _, poolNode := range nodePoolData {
 		//Find the sequence tag, which refers to options
 		if poolNode.Tag == "!!seq" {
@@ -462,8 +464,15 @@ func generateApplicationNodePoolOptions(nodePoolData []*yaml2.Node) string {
 					prefix = "  " //spaces instead of tabs
 					if strings.Contains(optionDatum.Value, "name") {
 						prefix = "- "
+						addSingleQuotes = true
 					}
-					optionChunk = append(optionChunk, "    "+prefix+optionDatum.Value+": "+optionNode.Content[idx+1].Value+"\n")
+					if addSingleQuotes {
+						optionChunkAppend = "    " + prefix + optionDatum.Value + ": '" + optionNode.Content[idx+1].Value + "'\n"
+					} else {
+						optionChunkAppend = "    " + prefix + optionDatum.Value + ": " + optionNode.Content[idx+1].Value + "\n"
+					}
+					optionChunk = append(optionChunk, optionChunkAppend)
+					addSingleQuotes = false
 				}
 				optionChunk = append(optionChunk, "")
 			}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -464,6 +464,8 @@ func generateApplicationNodePoolOptions(nodePoolData []*yaml2.Node) string {
 					prefix = "  " //spaces instead of tabs
 					if strings.Contains(optionDatum.Value, "name") {
 						prefix = "- "
+					}
+					if optionNode.Content[idx+1].Tag == "!!str" {
 						addSingleQuotes = true
 					}
 					if addSingleQuotes {

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/base64"
 	"fmt"
+	yaml2 "gopkg.in/yaml.v3"
 	"io/ioutil"
 	"log"
 	"os"
@@ -165,6 +166,9 @@ func GenerateKustomizeResult(config opConfig.Config, kustomizeTemplate template.
 
 	yamlFile.PutWithSeparator("applicationCoreuiImageTag", coreUiImageTag, ".")
 	yamlFile.PutWithSeparator("applicationCoreuiImagePullPolicy", coreUiImagePullPolicy, ".")
+
+	applicationNodePoolOptionsConfigMapStr := generateApplicationNodePoolOptions(yamlFile.GetValue("application.nodePool").Content)
+	yamlFile.PutWithSeparator("applicationNodePoolOptions", applicationNodePoolOptionsConfigMapStr, ".")
 
 	flatMap := yamlFile.FlattenToKeyValue(util.LowerCamelCaseFlatMapKeyFormatter)
 
@@ -440,4 +444,32 @@ func runKustomizeBuild(path string) (rm resmap.ResMap, err error) {
 	}
 
 	return rm, nil
+}
+
+func generateApplicationNodePoolOptions(nodePoolData []*yaml2.Node) string {
+	applicationNodePoolOptions := []string{"|\n"}
+	var optionChunk []string
+	var prefix string
+	for _, poolNode := range nodePoolData {
+		//Find the sequence tag, which refers to options
+		if poolNode.Tag == "!!seq" {
+			optionsNodes := poolNode.Content
+			for _, optionNode := range optionsNodes {
+				for idx, optionDatum := range optionNode.Content {
+					if idx%2 == 1 {
+						continue
+					}
+					prefix = "  " //spaces instead of tabs
+					if strings.Contains(optionDatum.Value, "name") {
+						prefix = "- "
+					}
+					optionChunk = append(optionChunk, "    "+prefix+optionDatum.Value+": "+optionNode.Content[idx+1].Value+"\n")
+				}
+				optionChunk = append(optionChunk, "")
+			}
+			break
+		}
+	}
+	applicationNodePoolOptions = append(applicationNodePoolOptions, strings.Join(optionChunk, ""))
+	return strings.Join(applicationNodePoolOptions, "")
 }


### PR DESCRIPTION
…at map.

- This supports a dynamic amount of options passed in by the user
in the params.yaml file.
Example output:
```
  databaseDriverName: postgres
  applicationNodePoolLabel: <node-pool-label>
  applicationNodePoolOptions: |
    - name: <name-1>
      value: <value-1>
    - name: <name-2>
      value: <value-2>
      default: true
```

closes https://github.com/onepanelio/core/issues/152