### PR TITLE
update: removed cloud settings

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -127,11 +127,16 @@ func GenerateKustomizeResult(config opConfig.Config, kustomizeTemplate template.
 		yamlFile.Put("providerType", "local")
 		yamlFile.Put("onepanelApiUrl", applicationApiUrl)
 	} else {
-		applicationApiPath := yamlFile.GetValue("application.cloud.apiPath").Value
-		applicationApiGrpcPort, _ := strconv.Atoi(yamlFile.GetValue("application.cloud.apiGRPCPort").Value)
-		applicationUiPath := yamlFile.GetValue("application.cloud.uiPath").Value
+		cloudSettings, err := util.LoadDynamicYamlFromFile(config.Spec.ManifestsRepo + string(os.PathSeparator) + "vars" + string(os.PathSeparator) + "onepanel-config-map-hidden.env")
+		if err != nil {
+			return "", err
+		}
 
-		insecure, _ := strconv.ParseBool(yamlFile.GetValue("application.cloud.insecure").Value)
+		applicationApiPath := cloudSettings.GetValue("applicationCloudApiPath").Value
+		applicationApiGrpcPort, _ := strconv.Atoi(cloudSettings.GetValue("applicationCloudApiGRPCPort").Value)
+		applicationUiPath := cloudSettings.GetValue("applicationCloudUiPath").Value
+
+		insecure, _ := strconv.ParseBool(yamlFile.GetValue("application.insecure").Value)
 		httpScheme := "http://"
 		wsScheme := "ws://"
 		if !insecure {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -236,9 +236,9 @@ var initCmd = &cobra.Command{
 
 		if mergedParams.HasKey("application.cloud") {
 			if EnableHTTPS {
-				mergedParams.Put("application.cloud.insecure", false)
+				mergedParams.Put("application.insecure", false)
 			} else {
-				mergedParams.Put("application.cloud.insecure", true)
+				mergedParams.Put("application.insecure", true)
 			}
 		}
 

--- a/util/url.go
+++ b/util/url.go
@@ -28,7 +28,7 @@ func GetDeployedWebURL(yamlFile *DynamicYaml) (string, error) {
 
 		fqdnExtra = fmt.Sprintf("%v", applicationUIPath)
 
-		insecure, err := strconv.ParseBool(yamlFile.GetValue("application.cloud.insecure").Value)
+		insecure, err := strconv.ParseBool(yamlFile.GetValue("application.insecure").Value)
 		if err != nil {
 			log.Fatal("insecure is not a bool")
 		}


### PR DESCRIPTION
updated references from application.cloud.insecure to application.insecure

updated references to cloud variables to be loaded from new file in manifests.

closes onepanelio/core#287 (along with manifests PR)