### PR TITLE
update: develop -> dev for images.

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -162,9 +162,9 @@ func GenerateKustomizeResult(config opConfig.Config, kustomizeTemplate template.
 	coreUiImageTag := opConfig.CoreUIImageTag
 	coreUiImagePullPolicy := "IfNotPresent"
 	if Dev {
-		coreImageTag = "develop"
+		coreImageTag = "dev"
 		coreImagePullPolicy = "Always"
-		coreUiImageTag = "develop"
+		coreUiImageTag = "dev"
 		coreUiImagePullPolicy = "Always"
 	}
 	yamlFile.PutWithSeparator("applicationCoreImageTag", coreImageTag, ".")


### PR DESCRIPTION
closes onepanelio/core#307 (along with new Core-UI and Core dev branches)