### PR TITLE
fix: core.344 manifests.cache.issue

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -116,7 +116,7 @@ var initCmd = &cobra.Command{
 		// When updating cli versions, the cli_config.yaml may already exist.
 		// Check if we need to generate a new cli_config.yaml, to match the cli version.
 		tag := config.ManifestsRepositoryTag
-		if source.GetSourceType() == manifest.SOURCE_GITHUB {
+		if source.GetSourceType() == manifest.SourceGithub {
 			if source.GetTag() != "" {
 				if tag != source.GetTag() {
 					if err := manifest.CreateGithubSourceConfigFile(configFile); err != nil {
@@ -131,7 +131,7 @@ var initCmd = &cobra.Command{
 				}
 			}
 		} else {
-			fmt.Printf("cli_config.yaml is using %v as source, ignoring CLI tag: %v", manifest.SOURCE_DIRECTORY, config.CLIVersion)
+			fmt.Printf("cli_config.yaml is using %v as source, ignoring CLI tag: %v", manifest.SourceDirectory, config.CLIVersion)
 		}
 
 		if err := source.MoveToDirectory(manifestsFilePath); err != nil {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -116,18 +116,22 @@ var initCmd = &cobra.Command{
 		// When updating cli versions, the cli_config.yaml may already exist.
 		// Check if we need to generate a new cli_config.yaml, to match the cli version.
 		tag := config.ManifestsRepositoryTag
-		if source.GetTag() != "" {
-			if tag != source.GetTag() {
-				if err := manifest.CreateGithubSourceConfigFile(configFile); err != nil {
-					log.Printf("[error] creating default source config: %v", err.Error())
-					return
-				}
-				source, err = manifest.LoadManifestSourceFromFileConfig(configFile)
-				if err != nil {
-					log.Printf("[error] loading manifest source: %v", err.Error())
-					return
+		if source.GetSourceType() == manifest.SOURCE_GITHUB {
+			if source.GetTag() != "" {
+				if tag != source.GetTag() {
+					if err := manifest.CreateGithubSourceConfigFile(configFile); err != nil {
+						log.Printf("[error] creating default source config: %v", err.Error())
+						return
+					}
+					source, err = manifest.LoadManifestSourceFromFileConfig(configFile)
+					if err != nil {
+						log.Printf("[error] loading manifest source: %v", err.Error())
+						return
+					}
 				}
 			}
+		} else {
+			fmt.Printf("cli_config.yaml is using %v as source, ignoring CLI tag: %v", manifest.SOURCE_DIRECTORY, config.CLIVersion)
 		}
 
 		if err := source.MoveToDirectory(manifestsFilePath); err != nil {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -113,6 +113,23 @@ var initCmd = &cobra.Command{
 			return
 		}
 
+		// When updating cli versions, the cli_config.yaml may already exist.
+		// Check if we need to generate a new cli_config.yaml, to match the cli version.
+		tag := config.ManifestsRepositoryTag
+		if source.GetTag() != "" {
+			if tag != source.GetTag() {
+				if err := manifest.CreateGithubSourceConfigFile(configFile); err != nil {
+					log.Printf("[error] creating default source config: %v", err.Error())
+					return
+				}
+				source, err = manifest.LoadManifestSourceFromFileConfig(configFile)
+				if err != nil {
+					log.Printf("[error] loading manifest source: %v", err.Error())
+					return
+				}
+			}
+		}
+
 		if err := source.MoveToDirectory(manifestsFilePath); err != nil {
 			log.Printf("[error] %v", err.Error())
 			return

--- a/manifest/source.go
+++ b/manifest/source.go
@@ -9,11 +9,17 @@ import (
 	"strings"
 )
 
+const (
+	SOURCE_GITHUB    = "github"
+	SOURCE_DIRECTORY = "directory"
+)
+
 type Source interface {
 	MoveToDirectory(destinationPath string) error
 	// Get the resulting manifest path. Should only be called after MoveToDirectory
 	GetManifestPath() (string, error)
 	GetTag() string
+	GetSourceType() string
 }
 
 type GithubSource struct {
@@ -32,6 +38,10 @@ func CreateGithubSource(tag string, overrideCache bool) (*GithubSource, error) {
 	}
 
 	return source, nil
+}
+
+func (g *GithubSource) GetSourceType() string {
+	return SOURCE_GITHUB
 }
 
 func (g *GithubSource) GetTag() string {
@@ -148,6 +158,10 @@ func CreateDirectorySource(sourceDirectory string, overrideCache bool) (*Directo
 	}
 
 	return source, nil
+}
+
+func (d *DirectorySource) GetSourceType() string {
+	return SOURCE_DIRECTORY
 }
 
 func (d *DirectorySource) GetTag() string {

--- a/manifest/source.go
+++ b/manifest/source.go
@@ -13,6 +13,7 @@ type Source interface {
 	MoveToDirectory(destinationPath string) error
 	// Get the resulting manifest path. Should only be called after MoveToDirectory
 	GetManifestPath() (string, error)
+	GetTag() string
 }
 
 type GithubSource struct {
@@ -31,6 +32,10 @@ func CreateGithubSource(tag string, overrideCache bool) (*GithubSource, error) {
 	}
 
 	return source, nil
+}
+
+func (g *GithubSource) GetTag() string {
+	return g.tag
 }
 
 func (g *GithubSource) getTagDownloadUrl() (string, error) {
@@ -143,6 +148,10 @@ func CreateDirectorySource(sourceDirectory string, overrideCache bool) (*Directo
 	}
 
 	return source, nil
+}
+
+func (d *DirectorySource) GetTag() string {
+	return ""
 }
 
 func (d *DirectorySource) getManifestPath(directoryPath string) string {

--- a/manifest/source.go
+++ b/manifest/source.go
@@ -10,7 +10,9 @@ import (
 )
 
 const (
-	SourceGithub    = "github"
+	//cli_config.yaml value, indicates manifests should be retrieved from github.
+	SourceGithub = "github"
+	//cli_config.yaml value, indicates manifests should be retrieved from some local directory.
 	SourceDirectory = "directory"
 )
 
@@ -40,10 +42,12 @@ func CreateGithubSource(tag string, overrideCache bool) (*GithubSource, error) {
 	return source, nil
 }
 
+// GetSourceType returns the string name of GithubSource.
 func (g *GithubSource) GetSourceType() string {
 	return SourceGithub
 }
 
+// GetTag returns the ManifestsRepositoryTag set in the CLI via build flag.
 func (g *GithubSource) GetTag() string {
 	return g.tag
 }
@@ -160,10 +164,13 @@ func CreateDirectorySource(sourceDirectory string, overrideCache bool) (*Directo
 	return source, nil
 }
 
+// GetSourceType returns the string name of DirectorySource.
 func (d *DirectorySource) GetSourceType() string {
 	return SourceDirectory
 }
 
+// GetTag returns the ManifestsRepositoryTag set in the CLI via build flag.
+// In this case, an empty string because DirectorySource doesn't have tags.
 func (d *DirectorySource) GetTag() string {
 	return ""
 }

--- a/manifest/source.go
+++ b/manifest/source.go
@@ -10,9 +10,15 @@ import (
 )
 
 const (
-	//cli_config.yaml value, indicates manifests should be retrieved from github.
+	// SourceGithub refers to cli_config.yaml,
+	// manifestSource:
+	//  github:
+	// This indicates manifests should be retrieved from github.
 	SourceGithub = "github"
-	//cli_config.yaml value, indicates manifests should be retrieved from some local directory.
+	// SourceDirectory refers to cli_config.yaml value,
+	// manifestSource:
+	//  directory:
+	// This indicates manifests should be retrieved from some local directory.
 	SourceDirectory = "directory"
 )
 

--- a/manifest/source.go
+++ b/manifest/source.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	SOURCE_GITHUB    = "github"
-	SOURCE_DIRECTORY = "directory"
+	SourceGithub    = "github"
+	SourceDirectory = "directory"
 )
 
 type Source interface {
@@ -41,7 +41,7 @@ func CreateGithubSource(tag string, overrideCache bool) (*GithubSource, error) {
 }
 
 func (g *GithubSource) GetSourceType() string {
-	return SOURCE_GITHUB
+	return SourceGithub
 }
 
 func (g *GithubSource) GetTag() string {
@@ -161,7 +161,7 @@ func CreateDirectorySource(sourceDirectory string, overrideCache bool) (*Directo
 }
 
 func (d *DirectorySource) GetSourceType() string {
-	return SOURCE_DIRECTORY
+	return SourceDirectory
 }
 
 func (d *DirectorySource) GetTag() string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. Please read our contributor guidelines: https://docs.onepanel.ai/docs/getting-started/contributing
2. Prefix the title of this PR with `feat:`, `fix:`, `docs:` or `chore:`, example: `feat: added great feature`
3. If this PR is a feature or enhancement, then create an issue (https://github.com/onepanelio/core/issues) first. 
-->

**What this PR does**:
Fixes the manifests not changing between CLI releases.

If you started with CLI 0.9.0, used `init`, you would get v.0.9.0 as your git source.
If you updated to CLI 0.10.0, used `init`, you would still have the v.0.9.0 as your git source.

With this change, the git source will properly match the CLI version.
- Note that this means a tag of "latest" will not work unless CLI version is set to "latest"
- If `cli_config.yaml` has a source of "directory", the CLI tag is ignored. The directory will continue to be used.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes onepanelio/core#<issue-number>`
-->
Fixes onepanelio/core#344

**Special notes for your reviewer**:
