### PR TITLE
fix: core.375 app.status.ip.address

### DIFF
--- a/util/kubectl.go
+++ b/util/kubectl.go
@@ -189,8 +189,16 @@ func GetClusterIp(url string) {
 		if provider == "minikube" || provider == "microk8s" {
 			fqdn := yamlFile.GetValue("application.fqdn").Value
 			fmt.Printf("\nIn your /etc/hosts file, add %v and point it to %v\n", stdout, fqdn)
+		} else {
+			dnsRecordMessage = "an A"
+			if !IsIpv4(stdout) {
+				dnsRecordMessage = "a CNAME"
+			}
+			fmt.Printf("\nIn your DNS, add %v record for %v and point it to %v\n", dnsRecordMessage, GetWildCardDNS(url), stdout)
 		}
-	} else {
+	}
+	//If yaml key is missing due to older params.yaml file, use this default.
+	if dnsRecordMessage == "" {
 		dnsRecordMessage = "an A"
 		if !IsIpv4(stdout) {
 			dnsRecordMessage = "a CNAME"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. Please read our contributor guidelines: https://docs.onepanel.ai/docs/getting-started/contributing
2. Prefix the title of this PR with `feat:`, `fix:`, `docs:` or `chore:`, example: `feat: added great feature`
3. If this PR is a feature or enhancement, then create an issue (https://github.com/onepanelio/core/issues) first. 
-->

**What this PR does**:
Fixes a regression. The DNS and IP information was not output when `opctl app status` was executed.
- Specifically, for cloud providers.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes onepanelio/core#<issue-number>`
-->
Fixes onepanelio/core#375

**Special notes for your reviewer**:
To test, have your kubectl pointing to a cloud deployment.
If you have the yaml key ```application.provider``` in your params.yaml, set it to a cloud provider such as `aks`.
If you do not have that key, the cli command will default to DNS and IP output.