### PR TITLE
fix: no artifact repository emitted an empty key in params.yaml

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -419,4 +419,11 @@ func removeUneededArtifactRepositoryProviders(mergedParams *util.DynamicYaml) {
 			}
 		}
 	}
+
+	parentValue := mergedParams.GetValue("artifactRepository")
+	if len(parentValue.Content) == 0 {
+		if err := mergedParams.Delete("artifactRepository"); err != nil {
+			log.Printf("error during init, artifact repository provider. %v", err)
+		}
+	}
 }


### PR DESCRIPTION
**What this PR does**:

Fixes an issue where not specifying an artifact repository gave you an empty curly brace result

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#480

**Special notes for your reviewer**:
