### PR TITLE
fix: Issue where duplicate entries appeared in params.yaml

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -225,7 +225,7 @@ var initCmd = &cobra.Command{
 			return
 		}
 
-		paramsFile, err := os.OpenFile(ParametersFilePath, os.O_RDWR, 0)
+		paramsFile, err := os.OpenFile(ParametersFilePath, os.O_RDWR|os.O_TRUNC, 0)
 		if err != nil {
 			log.Printf("Error opening parameters file: %v", err.Error())
 			return


### PR DESCRIPTION
**What this PR does**:

Fixes an issue where duplicate entries appeared in params.yaml

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#481

**Special notes for your reviewer**:

To reproduce (before this fix)

Run: 

```init --provider aks --enable-https --enable-cert-manager --dns-provider route53 --services modeldb --artifact-repository-provider s3```

Then

```init --provider aks --enable-https --enable-cert-manager --dns-provider route53 --services modeldb ```

The bottom two entries are duplicates.