### PR TITLE
fix: update onepanel core api version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/onepanelio/core v0.11.0
+	github.com/onepanelio/core v0.12.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -446,6 +446,8 @@ github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96d
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onepanelio/core v0.11.0 h1:gUpvaklqJCNw0J1MT9BQ3gCL1L9gzG8GgtaZDV8ZgEE=
 github.com/onepanelio/core v0.11.0/go.mod h1:XsTKBVpB0v4ulCjIBYKHT7LmlrqB3wtVM5wwoFwS7x8=
+github.com/onepanelio/core v0.12.0 h1:t7iqolhwQocbV60KswAh+hqAQKLksNzVu/xg7Xrt/xU=
+github.com/onepanelio/core v0.12.0/go.mod h1:2RYWMKfqDaRu61T18w1ncOX0wmbCd4vKAakDayw8Cuo=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
**What this PR does**:

Updates the `go.mod` reference to onepanel core to be 0.12.0.
This fixes a compilation issue.

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#

**Special notes for your reviewer**:
