### PR TITLE
fix: issue where downloading github zips sometimes didn't work

### DIFF
--- a/files/network.go
+++ b/files/network.go
@@ -1,19 +1,34 @@
 package files
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"os"
 )
 
 // DownloadFile will download a url to a local file.
+// The network request attaches the "onepanelio" user-agent to the request headers
+// This is important for certain sites like Github, otherwise you get a 403.
 func DownloadFile(filepath string, url string) error {
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Add("User-Agent", "onepanelio")
+
 	// Get the data
-	resp, err := http.Get(url)
+	resp, err := client.Do(req)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode > 399 {
+		return fmt.Errorf("[error] getting manifests. Response code %v", resp.StatusCode)
+	}
 
 	// Create the file
 	out, err := os.Create(filepath)


### PR DESCRIPTION
**What this PR does**:

Adds the user-agent header for github downloads. This fixes an issue where github downloads didn't work sometimes.

https://docs.github.com/en/rest/overview/resources-in-the-rest-api#user-agent-required

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes onepanelio/core#<issue-number>`
-->
Fixes onepanelio/core#552

**Special notes for your reviewer**:
