### PR TITLE
feat: Adding support for "--username / -u" parameter in `auth token` command.

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -9,6 +9,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	ServiceAccountName string
+)
+
 var authCmd = &cobra.Command{
 	Use:     "auth",
 	Short:   "Get authentication information.",
@@ -25,19 +29,26 @@ var tokenCmd = &cobra.Command{
 	Example: "auth token",
 	Run: func(cmd *cobra.Command, args []string) {
 		config := util.NewConfig()
-		token, err := util.GetBearerToken(config, "")
+		if ServiceAccountName == "" {
+			ServiceAccountName = "admin"
+		}
+		token, username, err := util.GetBearerToken(config, "", ServiceAccountName)
 		if err != nil {
-			fmt.Println("Error encountered: ", err.Error())
+			fmt.Printf("Error encountered for user %s: %s\n", username, err.Error())
 		}
 
-		currentTokenBytes := md5.Sum([]byte(token))
-		currentTokenString := hex.EncodeToString(currentTokenBytes[:])
+		if token != "" {
+			currentTokenBytes := md5.Sum([]byte(token))
+			currentTokenString := hex.EncodeToString(currentTokenBytes[:])
 
-		fmt.Println(currentTokenString)
+			fmt.Println(username)
+			fmt.Println(currentTokenString)
+		}
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(authCmd)
 	authCmd.AddCommand(tokenCmd)
+	tokenCmd.Flags().StringVarP(&ServiceAccountName, "username", "u", "", "Username you want the token for. Defaults to 'admin'")
 }

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -10,6 +10,7 @@ import (
 )
 
 var (
+	// This is the "username" we show to the user. We look up this value in k8s
 	ServiceAccountName string
 )
 

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	// This is the "username" we show to the user. We look up this value in k8s
+	// ServiceAccountName is the "username" we show to the user. We look up this value in k8s
 	ServiceAccountName string
 )
 


### PR DESCRIPTION
- If no parameter is passed in, 'admin' is default
-

<!--  Thanks for sending a pull request! Here are some tips for you:
1. Please read our contributor guidelines: https://docs.onepanel.ai/docs/getting-started/contributing
2. Prefix the title of this PR with `feat:`, `fix:`, `docs:` or `chore:`, example: `feat: added great feature`
3. If this PR is a feature or enhancement, then create an issue (https://github.com/onepanelio/core/issues) first. 
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes onepanelio/core#<issue-number>`
-->
Fixes onepanelio/core#664

**Special notes for your reviewer**:
Run `auth token --help` to see parameter help.