### PR TITLE
fix: Removing in.ExecProvider to prevent the wrong token being grabbed when using EKS clusters.

### DIFF
--- a/util/kubeconfig.go
+++ b/util/kubeconfig.go
@@ -7,10 +7,8 @@ import (
 	"net/http"
 	"os"
 	"regexp"
-	"strings"
 	"time"
 
-	"k8s.io/client-go/plugin/pkg/client/auth/exec"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/transport"
@@ -31,33 +29,6 @@ func NewConfig() (config *Config) {
 func GetBearerToken(in *restclient.Config, explicitKubeConfigPath string, serviceAccountName string) (token string, username string, err error) {
 	if in == nil {
 		return "", serviceAccountName, errors.Errorf("RestClient can't be nil")
-	}
-
-	if in.ExecProvider != nil {
-		tc, err := in.TransportConfig()
-		if err != nil {
-			return "", serviceAccountName, err
-		}
-
-		auth, err := exec.GetAuthenticator(in.ExecProvider)
-		if err != nil {
-			return "", serviceAccountName, err
-		}
-
-		//This function will return error because of TLS Cert missing,
-		// This code is not making actual request. We can ignore it.
-		_ = auth.UpdateTransportConfig(tc)
-
-		rt, err := transport.New(tc)
-		if err != nil {
-			return "", serviceAccountName, err
-		}
-		req := http.Request{Header: map[string][]string{}}
-
-		_, _ = rt.RoundTrip(&req)
-
-		token := req.Header.Get("Authorization")
-		return strings.TrimPrefix(token, "Bearer "), serviceAccountName, nil
 	}
 
 	kubeClient, err := kubernetes.NewForConfig(in)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. Please read our contributor guidelines: https://docs.onepanel.ai/docs/getting-started/contributing
2. Prefix the title of this PR with `feat:`, `fix:`, `docs:` or `chore:`, example: `feat: added great feature`
3. If this PR is a feature or enhancement, then create an issue (https://github.com/onepanelio/core/issues) first. 
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes onepanelio/core#<issue-number>`
-->
Fixes onepanelio/core#

**Special notes for your reviewer**:
