### PR TITLE
feat: added comment used in init to be output to params.yaml

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -227,6 +227,13 @@ var initCmd = &cobra.Command{
 		removeUneededArtifactRepositoryProviders(mergedParams)
 
 		mergedParams.Sort()
+
+		inputCommand := "# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -\n"
+		inputCommand += "# Init command: opctl " + strings.Join(os.Args[1:], " ")
+		if err := mergedParams.SetTopComment(inputCommand); err != nil {
+			log.Printf("[error] setting comments: %v", err.Error())
+			return
+		}
 		paramsString, err := mergedParams.String()
 		if err != nil {
 			log.Printf("[error] unable to write params to a string")
@@ -445,7 +452,7 @@ func removeUneededArtifactRepositoryProviders(mergedParams *util.DynamicYaml) {
 	}
 
 	parentValue := mergedParams.GetValue("artifactRepository")
-	if len(parentValue.Content) == 0 {
+	if parentValue != nil && len(parentValue.Content) == 0 {
 		if err := mergedParams.Delete("artifactRepository"); err != nil {
 			log.Printf("error during init, artifact repository provider. %v", err)
 		}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -229,7 +229,9 @@ var initCmd = &cobra.Command{
 		mergedParams.Sort()
 
 		inputCommand := "# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -\n"
-		inputCommand += "# Init command: opctl " + strings.Join(os.Args[1:], " ")
+		inputCommand += "# Generated with Onepanel CLI \n"
+		inputCommand += "# Command: opctl " + strings.Join(os.Args[1:], " ") + "\n"
+		inputCommand += "# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -"
 		if err := mergedParams.SetTopComment(inputCommand); err != nil {
 			log.Printf("[error] setting comments: %v", err.Error())
 			return

--- a/util/dynamic_yaml.go
+++ b/util/dynamic_yaml.go
@@ -112,14 +112,7 @@ func (d *DynamicYaml) SetTopComment(comment string) error {
 		return fmt.Errorf("DynamicYaml has not been loaded yet")
 	}
 
-	if len(d.node.Content) == 0 {
-		d.node.HeadComment = comment
-		return nil
-	}
-
-	// If we have nodes, then we need to set it to the top-most node's comment
-	// Otherwise we get a blank line in the resulting yaml
-	d.node.Content[0].HeadComment = comment
+	d.node.HeadComment = comment
 
 	return nil
 }

--- a/util/dynamic_yaml.go
+++ b/util/dynamic_yaml.go
@@ -630,8 +630,8 @@ func (d *DynamicYaml) mergeSingle(y *DynamicYaml) {
 		valueNode := values.Content[i+1]
 
 		alreadyExists := false
-		var jKey *yaml.Node = nil
-		var jValue *yaml.Node = nil
+		var jKey *yaml.Node
+		var jValue *yaml.Node
 		for j := 0; j < len(destination.Content)-1; j++ {
 			jKey = destination.Content[j]
 			jValue = destination.Content[j+1]


### PR DESCRIPTION
**What this PR does**:

Adds the init command used to be output in params.yaml.

Sample:

```
# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
# Init command: opctl init --provider aks --enable-https --enable-cert-manager --dns-provider route53 --artifact-repository-provider=s3 --gpu-device-plugins nvidia
# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
# Component: Onepanel
# Description: Onepanel application information
# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
application:...
```

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#666

**Special notes for your reviewer**:
