### PR TITLE
fix: Using filepath, since it creates platform specific filepath separators.

### DIFF
--- a/manifest/builder.go
+++ b/manifest/builder.go
@@ -5,7 +5,6 @@ import (
 	"github.com/onepanelio/cli/files"
 	"github.com/onepanelio/cli/util"
 	"log"
-	"path"
 	"path/filepath"
 	"strings"
 )
@@ -121,7 +120,7 @@ func (b *Builder) AddCommonComponents(skipComponents ...string) error {
 		component := b.manifest.components[key]
 
 		if component.IsCommon() {
-			if strings.Contains(component.Path(), path.Join("common", "argo", "source")) {
+			if strings.Contains(component.Path(), filepath.Join("common", "argo", "source")) {
 				continue
 			}
 			if err := b.AddComponent(component.path); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. Please read our contributor guidelines: https://docs.onepanel.ai/docs/getting-started/contributing
2. Prefix the title of this PR with `feat:`, `fix:`, `docs:` or `chore:`, example: `feat: added great feature`
3. If this PR is a feature or enhancement, then create an issue (https://github.com/onepanelio/core/issues) first. 
-->

**What this PR does**:
This fixes `common\argo\source\base` being included during `opctl init`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes onepanelio/core#<issue-number>`
-->
Fixes onepanelio/core#

**Special notes for your reviewer**:
