### PR TITLE
fix: catch errors with defaultNamespace in params.yaml

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -40,7 +40,7 @@ var applyCmd = &cobra.Command{
 		applicationBaseKustomizeTemplate := TemplateFromSimpleOverlayedComponents(baseOverlayComponent)
 		applicationResult, err := GenerateKustomizeResult(*config, applicationBaseKustomizeTemplate)
 		if err != nil {
-			log.Printf("Error generating result %v", err.Error())
+			fmt.Printf("%s\n", HumanizeKustomizeError(err))
 			return
 		}
 
@@ -126,7 +126,7 @@ var applyCmd = &cobra.Command{
 
 		result, err := GenerateKustomizeResult(*config, kustomizeTemplate)
 		if err != nil {
-			log.Printf("Error generating result %v", err.Error())
+			fmt.Printf("%s\n", HumanizeKustomizeError(err))
 			return
 		}
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -610,13 +610,15 @@ func mapLinkedVars(mapping map[string]interface{}, manifestPath string, config *
 
 // HumanizeKustomizeError takes errors returned from GenerateKustomizeResult and returns them in a human friendly string
 func HumanizeKustomizeError(err error) string {
-	switch err.Error() {
-	case "application.defaultNamespace.missing":
-		return "application.defaultNamespace is missing in your params.yaml"
-	case "application.defaultNamespace.blank":
-		return "application.defaultNamespace can not be blank please use a different namespace in your params.yaml"
-	case "application.defaultNamespace.reserved":
-		return "application.defaultNamespace can not be 'onepanel' please use a different namespace in your params.yaml"
+	if paramsError, ok := err.(*manifest.ParamsError); ok {
+		switch paramsError.ErrorType {
+		case "missing":
+			return fmt.Sprintf("%s is missing in your params.yaml", paramsError.Key)
+		case "blank":
+			return fmt.Sprintf("%s can not be blank, please use a different namespace in your params.yaml", paramsError.Key)
+		case "reserved":
+			return fmt.Sprintf("%s can not be '%v' please use a different namespace in your params.yaml", paramsError.Key, *paramsError.Value)
+		}
 	}
 
 	return fmt.Sprintf("Error generating result: %v", err.Error())

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -54,7 +54,7 @@ var generateCmd = &cobra.Command{
 		log.Printf("Building...")
 		result, err := GenerateKustomizeResult(*config, kustomizeTemplate)
 		if err != nil {
-			log.Printf("Error generating result %v", err.Error())
+			fmt.Printf("%s\n", HumanizeKustomizeError(err))
 			return
 		}
 
@@ -71,6 +71,15 @@ func init() {
 // It does this by copying the manifests into a temporary directory, inserting the kustomize template
 // and running the kustomize command
 func GenerateKustomizeResult(config opConfig.Config, kustomizeTemplate template.Kustomize) (string, error) {
+	yamlFile, err := util.LoadDynamicYamlFromFile(config.Spec.Params)
+	if err != nil {
+		return "", err
+	}
+
+	if err := manifest.Validate(yamlFile); err != nil {
+		return "", err
+	}
+
 	manifestPath := config.Spec.ManifestsRepo
 	localManifestsCopyPath := filepath.Join(".onepanel/manifests/cache")
 
@@ -106,11 +115,6 @@ func GenerateKustomizeResult(config opConfig.Config, kustomizeTemplate template.
 	}
 
 	_, err = newFile.Write(kustomizeYaml)
-	if err != nil {
-		return "", err
-	}
-
-	yamlFile, err := util.LoadDynamicYamlFromFile(config.Spec.Params)
 	if err != nil {
 		return "", err
 	}
@@ -602,4 +606,18 @@ func mapLinkedVars(mapping map[string]interface{}, manifestPath string, config *
 	}
 
 	return nil
+}
+
+// HumanizeKustomizeError takes errors returned from GenerateKustomizeResult and returns them in a human friendly string
+func HumanizeKustomizeError(err error) string {
+	switch err.Error() {
+	case "application.defaultNamespace.missing":
+		return "application.defaultNamespace is missing in your params.yaml"
+	case "application.defaultNamespace.blank":
+		return "application.defaultNamespace can not be blank please use a different namespace in your params.yaml"
+	case "application.defaultNamespace.reserved":
+		return "application.defaultNamespace can not be 'onepanel' please use a different namespace in your params.yaml"
+	}
+
+	return fmt.Sprintf("Error generating result: %v", err.Error())
 }

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -1,7 +1,7 @@
 package manifest
 
 import (
-	"errors"
+	"fmt"
 	"github.com/onepanelio/cli/util"
 	"log"
 	"os"
@@ -13,6 +13,22 @@ type Manifest struct {
 	path       string // where the manifest directory is located
 	components map[string]*Component
 	overlays   map[string]*Overlay
+}
+
+// ParamsError represents an error encountered in the params.yaml file
+type ParamsError struct {
+	Key       string
+	Value     *string
+	ErrorType string
+}
+
+// Error returns an error string indicating what key/value is invalid
+func (p *ParamsError) Error() string {
+	if p.Value == nil {
+		return fmt.Sprintf("%s is invalid", p.Key)
+	}
+
+	return fmt.Sprintf("%s: %s is invalid", p.Key, *p.Value)
 }
 
 func LoadManifest(manifestRoot string) (*Manifest, error) {
@@ -101,16 +117,25 @@ func (m *Manifest) GetOverlay(path string) *Overlay {
 
 // Validate checks if the manifest is valid. If it is, nil is returned. Otherwise an error is returned.
 func Validate(manifest *util.DynamicYaml) error {
-	defaultNamespace := manifest.GetValue("application.defaultNamespace")
-	if defaultNamespace == nil {
-		return errors.New("application.defaultNamespace.missing")
+	reservedNamespaces := map[string]bool{
+		"onepanel":           true,
+		"application-system": true,
+		"cert-manager":       true,
+		"istio-system":       true,
+		"knative-serving":    true,
+		"kube-public":        true,
+		"kube-system":        true,
 	}
 
-	if defaultNamespace.Value == "" {
-		return errors.New("application.defaultNamespace.blank")
+	defaultNamespace := manifest.GetValue("application.defaultNamespace")
+	if defaultNamespace == nil {
+		return &ParamsError{Key: "application.defaultNamespace", ErrorType: "missing"}
 	}
-	if defaultNamespace.Value == "onepanel" {
-		return errors.New("application.defaultNamespace.reserved")
+	if defaultNamespace.Value == "" {
+		return &ParamsError{Key: "application.defaultNamespace", ErrorType: "blank"}
+	}
+	if _, ok := reservedNamespaces[defaultNamespace.Value]; ok {
+		return &ParamsError{Key: "application.defaultNamespace", Value: &defaultNamespace.Value, ErrorType: "reserved"}
 	}
 
 	return nil

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -1,6 +1,8 @@
 package manifest
 
 import (
+	"errors"
+	"github.com/onepanelio/cli/util"
 	"log"
 	"os"
 	"path/filepath"
@@ -95,4 +97,21 @@ func (m *Manifest) GetComponent(path string) *Component {
 
 func (m *Manifest) GetOverlay(path string) *Overlay {
 	return m.overlays[path]
+}
+
+// Validate checks if the manifest is valid. If it is, nil is returned. Otherwise an error is returned.
+func Validate(manifest *util.DynamicYaml) error {
+	defaultNamespace := manifest.GetValue("application.defaultNamespace")
+	if defaultNamespace == nil {
+		return errors.New("application.defaultNamespace.missing")
+	}
+
+	if defaultNamespace.Value == "" {
+		return errors.New("application.defaultNamespace.blank")
+	}
+	if defaultNamespace.Value == "onepanel" {
+		return errors.New("application.defaultNamespace.reserved")
+	}
+
+	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. Please read our contributor guidelines: https://docs.onepanel.ai/docs/getting-started/contributing
2. Prefix the title of this PR with `feat:`, `fix:`, `docs:` or `chore:`, example: `feat: added great feature`
3. If this PR is a feature or enhancement, then create an issue (https://github.com/onepanelio/core/issues) first. 
-->

**What this PR does**:

Catches errors with params.yaml when the default namespace is blank, missing, or a reserved namespace.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes onepanelio/core#<issue-number>`
-->
Fixes onepanelio/core#748

**Special notes for your reviewer**:
