### PR TITLE
feat: show current context when deleting deployments

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -14,6 +14,7 @@ import (
 var (
 	// skipConfirmDelete if true, will skip the confirmation prompt of the delete command
 	skipConfirmDelete bool
+	options           *clientcmd.PathOptions
 )
 
 var deleteCmd = &cobra.Command{
@@ -23,7 +24,13 @@ var deleteCmd = &cobra.Command{
 	Example: "delete",
 	Run: func(cmd *cobra.Command, args []string) {
 		if skipConfirmDelete == false {
-			fmt.Print("Are you sure you want to delete onepanel? ('y' or 'yes' to confirm. Anything else to cancel): ")
+			options := clientcmd.NewDefaultPathOptions()
+			config, err := options.GetStartingConfig()
+			if err != nil {
+				return
+			}
+			fmt.Printf("The current kubernetes context is: %s \n", config.CurrentContext)
+			fmt.Printf("Are you sure you want to delete onepanel from '%s'? ('y' or 'yes' to confirm. Anything else to cancel): ", config.CurrentContext)
 			userInput := ""
 			if _, err := fmt.Scanln(&userInput); err != nil {
 				fmt.Printf("Unable to get response\n")
@@ -91,18 +98,7 @@ var deleteCmd = &cobra.Command{
 	},
 }
 
-func RunCurrentContext(options *clientcmd.PathOptions) error {
-	config, err := options.GetStartingConfig()
-	if err != nil {
-		return err
-	}
-	fmt.Printf("The current kubernetes context is: %s \n", config.CurrentContext)
-	return nil
-}
-
 func init() {
-	pathOptions := clientcmd.NewDefaultPathOptions()
-	RunCurrentContext(pathOptions)
 	rootCmd.AddCommand(deleteCmd)
 	deleteCmd.Flags().BoolVarP(&skipConfirmDelete, "yes", "y", false, "Add this in to skip the confirmation prompt")
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -2,11 +2,13 @@ package cmd
 
 import (
 	"fmt"
+	"path/filepath"
+
 	opConfig "github.com/onepanelio/cli/config"
 	"github.com/onepanelio/cli/files"
 	"github.com/onepanelio/cli/util"
 	"github.com/spf13/cobra"
-	"path/filepath"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 var (
@@ -89,7 +91,18 @@ var deleteCmd = &cobra.Command{
 	},
 }
 
+func RunCurrentContext(options *clientcmd.PathOptions) error {
+	config, err := options.GetStartingConfig()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("The current kubernetes context is: %s \n", config.CurrentContext)
+	return nil
+}
+
 func init() {
+	pathOptions := clientcmd.NewDefaultPathOptions()
+	RunCurrentContext(pathOptions)
 	rootCmd.AddCommand(deleteCmd)
 	deleteCmd.Flags().BoolVarP(&skipConfirmDelete, "yes", "y", false, "Add this in to skip the confirmation prompt")
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -14,7 +14,6 @@ import (
 var (
 	// skipConfirmDelete if true, will skip the confirmation prompt of the delete command
 	skipConfirmDelete bool
-	options           *clientcmd.PathOptions
 )
 
 var deleteCmd = &cobra.Command{
@@ -27,9 +26,11 @@ var deleteCmd = &cobra.Command{
 			options := clientcmd.NewDefaultPathOptions()
 			config, err := options.GetStartingConfig()
 			if err != nil {
+				fmt.Printf("Unable to get kubernetes config: %v", err.Error())
 				return
 			}
-			fmt.Printf("The current kubernetes context is: %s \n", config.CurrentContext)
+
+			fmt.Println("The current kubernetes context is:", config.CurrentContext)
 			fmt.Printf("Are you sure you want to delete onepanel from '%s'? ('y' or 'yes' to confirm. Anything else to cancel): ", config.CurrentContext)
 			userInput := ""
 			if _, err := fmt.Scanln(&userInput); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. Please read our contributor guidelines: https://docs.onepanel.ai/docs/getting-started/contributing
2. Prefix the title of this PR with `feat:`, `fix:`, `docs:` or `chore:`, example: `feat: added great feature`
3. If this PR is a feature or enhancement, then create an issue (https://github.com/onepanelio/core/issues) first. 
-->

**What this PR does**:

Prints out the current kubernetes conext before delete command prompt.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes onepanelio/core#<issue-number>`
-->
Fixes onepanelio/core#926

**Special notes for your reviewer**:
